### PR TITLE
fix/compare-enums-as-numbers

### DIFF
--- a/templates/funcs.go
+++ b/templates/funcs.go
@@ -30,14 +30,13 @@ func getter(n pgs.Name, t pgs.FieldType) string {
 	s := fmt.Sprintf("c.Get%s()", n.UpperCamelCase())
 
 	if t.IsEnum() {
-		return s + ".String()"
+		return s
 	}
 
 	return s
 }
 
 func name(f pgs.Field) string {
-
 	if f.InOneOf() {
 		return f.OneOf().Name().String()
 	}
@@ -62,7 +61,6 @@ func isSimple(t pgs.ProtoType) bool {
 }
 
 func simpleAddFunc(n pgs.Name, t pgs.FieldType) string {
-
 	switch t.ProtoType() {
 	case pgs.EnumT:
 		return "AddString"
@@ -105,7 +103,6 @@ func simpleAddFunc(n pgs.Name, t pgs.FieldType) string {
 }
 
 func arrayFunc(typ pgs.FieldType) string {
-
 	switch typ.Element().ProtoType() {
 	case pgs.DoubleT:
 		// proto: double
@@ -223,7 +220,6 @@ func render(f pgs.Field) string {
 
 	// repeated
 	if t.IsRepeated() {
-
 		if t.Element().IsEnum() || (t.Element().IsEmbed() && t.Element().Embed().IsWellKnown()) {
 			d := newArrayData("Stringers", getter(n, t), name(f))
 			tpl := template.New("stringers")
@@ -244,7 +240,6 @@ func render(f pgs.Field) string {
 
 		} else if isSimple(t.Element().ProtoType()) {
 			s = fmt.Sprintf(`o.AddArray("%s", utils.%s(%s))`, name(f), arrayFunc(t), getter(n, t))
-
 		} else {
 			d := newArrayData("Interfaces", getter(n, t), name(f))
 			tpl := template.New("interfaces")

--- a/templates/funcs.go
+++ b/templates/funcs.go
@@ -30,7 +30,7 @@ func getter(n pgs.Name, t pgs.FieldType) string {
 	s := fmt.Sprintf("c.Get%s()", n.UpperCamelCase())
 
 	if t.IsEnum() {
-		return s
+		return s + ".String()"
 	}
 
 	return s
@@ -266,7 +266,15 @@ func render(f pgs.Field) string {
 	// if oneof wrap in <if not empty>
 	// not required if already wrapped (for embed types)
 	if f.OneOf() != nil && !strings.Contains(s, "!= nil") {
-		s = fmt.Sprintf(oneoftpl, getter(n, t), zeroValue(t), s)
+		g := getter(n, t)
+
+		if t.IsEnum() {
+			// getter() return the string value of enums.
+			// but enums can't be compared as string in one of marshaling.
+			g = fmt.Sprintf("c.Get%s()", n.UpperCamelCase())
+		}
+
+		s = fmt.Sprintf(oneoftpl, g, zeroValue(t), s)
 	}
 
 	return s


### PR DESCRIPTION
Fix zap `oneof` filtering for enum fields.

[Issue](https://github.com/bigbluedisco/proto-go-carriers/blob/master/v0/warehousepreparationdelay.pb.zap.go#L48):
```go
// MarshalLogObject makes MethodDelay implement zap.ObjectMarshaler
func (c MethodDelay) MarshalLogObject(o zapcore.ObjectEncoder) error {
	if c.GetDeliveryMethod().String() != 0 {
		o.AddString("method", c.GetDeliveryMethod().String())
	}
	...
}
```

expected:
```go

// MarshalLogObject makes MethodDelay implement zap.ObjectMarshaler
func (c MethodDelay) MarshalLogObject(o zapcore.ObjectEncoder) error {
	if c.GetDeliveryMethod() != 0 {
		o.AddString("method", c.GetDeliveryMethod().String())
	}
	...
}
```