### PR TITLE
fix/prevent-nil-pointer-exception

### DIFF
--- a/templates/messagetpl.go
+++ b/templates/messagetpl.go
@@ -3,7 +3,10 @@ package templates
 const messageTpl = `
 
 // MarshalLogObject makes {{ go_type_name . }} implement zap.ObjectMarshaler
-func (c {{ go_type_name . }}) MarshalLogObject(o zapcore.ObjectEncoder) error {
+func (c *{{ go_type_name . }}) MarshalLogObject(o zapcore.ObjectEncoder) error {
+	if c == nil {
+		return nil
+	}
 
 	{{ range .Fields }}
 		


### PR DESCRIPTION
Prevent nil pointer exceptions by implementing MarshalLogObject on pointers, not values, and doing a nil check first.